### PR TITLE
binding.pry を使えるように

### DIFF
--- a/nova/Gemfile
+++ b/nova/Gemfile
@@ -31,6 +31,8 @@ gem 'aws-sdk-codedeploy'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'pry-rails'
+  gem 'pry-byebug'
 
   gem 'factory_bot_rails'
   gem 'rspec-rails'

--- a/nova/Gemfile.lock
+++ b/nova/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       xpath (~> 3.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     dante (0.2.0)
@@ -140,6 +141,14 @@ GEM
     parser (2.5.1.0)
       ast (~> 2.4.0)
     powerpack (0.1.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
@@ -296,6 +305,8 @@ DEPENDENCIES
   locale_kit
   meta-tags
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-byebug
+  pry-rails
   puma (~> 3.7)
   rails (~> 5.2.0)
   rails-controller-testing

--- a/nova/config/puma.rb
+++ b/nova/config/puma.rb
@@ -3,7 +3,10 @@
 APP_ROOT = File.expand_path(File.join(__dir__, '..'))
 directory APP_ROOT
 pidfile File.join(APP_ROOT, 'tmp', 'pids', 'puma.pid')
-stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'log', 'stderr.log'), true
+
+if Rails.env.production?
+  stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'log', 'stderr.log'), true
+end
 
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.


### PR DESCRIPTION
その際、pumaが標準出力と標準エラー出力をログに吐いていたので、production環境以外ではコンソールに吐くように