### PR TITLE
#20 により本番でpumaが起動しない問題を修正

### DIFF
--- a/nova/config/puma.rb
+++ b/nova/config/puma.rb
@@ -4,7 +4,7 @@ APP_ROOT = File.expand_path(File.join(__dir__, '..'))
 directory APP_ROOT
 pidfile File.join(APP_ROOT, 'tmp', 'pids', 'puma.pid')
 
-if Rails.env.production?
+if ENV['RAILS_ENV'] == 'production'
   stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'log', 'stderr.log'), true
 end
 


### PR DESCRIPTION
https://github.com/0gajun/2018-newbies/pull/20#pullrequestreview-118176080

の指摘により発覚。

ローカルでは `./bin/rails s` で起動していて railsが既に読み込まれていて`Rails.env`にアクセスできた一方、CodeDeployでの起動スクリプトでは `bundle exec puma` で起動しているためrailsが読み込まれていなかった。

よって `Rails.env` ではなく、`ENV['RAILS_ENV']` を用いて現在の環境を判断するように変更。

