### PR TITLE
Wait for MySQL ready in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,11 @@ jobs:
             - ./nova/vendor/bundle
           key: v1-dependencies-{{ checksum "nova/Gemfile.lock" }}
 
+      - run:
+          name: Wait for DB
+          # preinstalled in circleci/* docker image
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
+
       # Database setup
       - run: cd nova && bundle exec rake db:create
       - run: cd nova && bundle exec rake db:schema:load


### PR DESCRIPTION
CircleCIで、MySQLの起動完了前にDBアクセスをしようとして落ちているものがある。

これを解決するために、MySQLの起動完了を待ってからDBにアクセスするステップに進むようにした。