### PR TITLE
RemitRequest分割で不要になったカラムの削除

### DIFF
--- a/nova/app/controllers/api/charges_controller.rb
+++ b/nova/app/controllers/api/charges_controller.rb
@@ -7,10 +7,10 @@ class Api::ChargesController < Api::ApplicationController
       charge_total += charge.amount
     end
     remit_total = 0
-    current_user.received_remit_requests.where.not(accepted_at: nil).each do |remit|
+    current_user.received_remit_request_results.accepted.each do |remit|
       remit_total += remit.amount
     end
-    current_user.sent_remit_requests.where.not(accepted_at: nil).each do |remit|
+    current_user.sent_remit_request_results.accepted.each do |remit|
       remit_total -= remit.amount
     end
     balance_total = charge_total - remit_total

--- a/nova/app/models/remit_request.rb
+++ b/nova/app/models/remit_request.rb
@@ -6,30 +6,6 @@ class RemitRequest < ApplicationRecord
 
   validates :amount, numericality: { greater_then: 0 }
 
-  scope :outstanding, ->(at = Time.current) { not_accepted(at).not_rejected(at).not_canceled(at) }
-  scope :accepted, ->(at = Time.current) { where(RemitRequest.arel_table[:accepted_at].lteq(at)) }
-  scope :not_accepted, ->(at = Time.current) { where(accepted_at: nil).or(where(RemitRequest.arel_table[:accepted_at].gt(at))) }
-  scope :rejected, ->(at = Time.current) { where(RemitRequest.arel_table[:rejected_at].lteq(at)) }
-  scope :not_rejected, ->(at = Time.current) { where(rejected_at: nil).or(where(RemitRequest.arel_table[:rejected_at].gt(at))) }
-  scope :canceled, ->(at = Time.current) { where(RemitRequest.arel_table[:canceled_at].lteq(at)) }
-  scope :not_canceled, ->(at = Time.current) { where(canceled_at: nil).or(where(RemitRequest.arel_table[:canceled_at].gt(at))) }
-
-  def outstanding?(at = Time.current)
-    !accepted?(at) && !rejected?(at) && !canceled?(at)
-  end
-
-  def accepted?(at = Time.current)
-    accepted_at && accepted_at <= at
-  end
-
-  def rejected?(at = Time.current)
-    rejected_at && rejected_at <= at
-  end
-
-  def canceled?(at = Time.current)
-    canceled_at && canceled_at <= at
-  end
-
   def accept!
     RemitService.execute!(self)
   end

--- a/nova/db/migrate/20180511021839_remove_unused_columns_to_remit_requests.rb
+++ b/nova/db/migrate/20180511021839_remove_unused_columns_to_remit_requests.rb
@@ -1,0 +1,7 @@
+class RemoveUnusedColumnsToRemitRequests < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :remit_requests, :accepted_at, :datetime
+    remove_column :remit_requests, :rejected_at, :datetime
+    remove_column :remit_requests, :canceled_at, :datetime
+  end
+end

--- a/nova/db/schema.rb
+++ b/nova/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_11_013408) do
+ActiveRecord::Schema.define(version: 2018_05_11_021839) do
 
   create_table "balances", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -68,9 +68,6 @@ ActiveRecord::Schema.define(version: 2018_05_11_013408) do
     t.bigint "user_id", null: false
     t.bigint "requested_user_id", null: false
     t.integer "amount", null: false
-    t.datetime "accepted_at"
-    t.datetime "rejected_at"
-    t.datetime "canceled_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["requested_user_id"], name: "index_remit_requests_on_requested_user_id"

--- a/nova/spec/factories/remit_requests.rb
+++ b/nova/spec/factories/remit_requests.rb
@@ -5,23 +5,5 @@ FactoryBot.define do
     user { create(:user) }
     requested_user { create(:user) }
     amount 100
-
-    trait :outstanding do
-      accepted_at nil
-      rejected_at nil
-      canceled_at nil
-    end
-
-    trait :accepted do
-      accepted_at { Time.current }
-    end
-
-    trait :rejected do
-      rejected_at { Time.current }
-    end
-
-    trait :canceled do
-      canceled_at { Time.current }
-    end
   end
 end


### PR DESCRIPTION
#60 のマージが先です 😉 

#54 にて、 `RemitRequest` が状態を持たないようになった :tada:

よって、状態管理に必要な以下のカラムを削除する
* `accepted_at`
* `rejected_at`
* `canceled_at`
