### PR TITLE
Protect api from CSRF attacks

### DIFF
--- a/nova/app/controllers/api/application_controller.rb
+++ b/nova/app/controllers/api/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::ApplicationController < ActionController::API
+  ENDPOINT_SCHEME = 'http' # TODO: 設定値にする
+
   include AbstractController::Translation
 
   rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
@@ -8,11 +10,27 @@ class Api::ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   before_action :required_login!
+  before_action :verify_request_from_same_origin
 
   protected
 
   def required_login!
     render(json: { errors: [t('api.application.errors.unauthorized')] }, status: :unauthorized) unless user_signed_in?
+  end
+
+  # `/api` に対するCSRFを防ぐために、リクエスト先のHostとOriginが一致するかをチェックする
+  # novaの画面からリクエストされたアクセスのみを許可する。
+  def verify_request_from_same_origin
+    source_origin = request.origin || request.referer
+    target_origin = request.headers['Host'] # port 情報も合わせて取得するためにheadersに直接アクセスする
+
+    if source_origin && target_origin
+      source = URI.parse(source_origin)
+      target = URI.parse("#{ENDPOINT_SCHEME}://#{target_origin}")
+      return if source.scheme == target.scheme && source.host == target.host && source.port == target.port
+    end
+
+    render json: { errors: ["cross site request is not allowed"] }, status: :forbidden
   end
 
   def record_invalid(exception)

--- a/nova/spec/controllers/api/application_controller_spec.rb
+++ b/nova/spec/controllers/api/application_controller_spec.rb
@@ -3,4 +3,51 @@
 require 'rails_helper'
 
 RSpec.describe Api::ApplicationController, type: :controller do
+
+  let(:user) { create(:user) }
+
+  describe "before_action :verify_request_from_same_origin" do
+    controller do
+      def index
+        render plain: "ok"
+      end
+    end
+
+    subject { get :index }
+
+    before { sign_in(user) }
+
+    context 'with correct headers' do
+      include_context 'request from nova site'
+
+      it { is_expected.to have_http_status(:ok) }
+    end
+
+    context 'with incorrect headers' do
+      before do
+        request.headers['Host'] = 'example.com'
+        request.headers['Origin'] = 'http://evil.example.co.jp'
+      end
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+
+    context 'with empty origin header' do
+      before do
+        request.headers['Host'] = 'example.com'
+        request.headers['Origin'] = ''
+      end
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+
+    context 'with empty host header' do
+      before do
+        request.headers['Host'] = ''
+        request.headers['Origin'] = 'http://example.com'
+      end
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+  end
 end

--- a/nova/spec/controllers/api/charges_controller_spec.rb
+++ b/nova/spec/controllers/api/charges_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Api::ChargesController, type: :controller do
+  include_context 'request from nova site'
+
   let(:user) { create(:user) }
 
   describe 'GET #index' do

--- a/nova/spec/controllers/api/credit_cards_controller_spec.rb
+++ b/nova/spec/controllers/api/credit_cards_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Api::CreditCardsController, type: :controller do
+  include_context 'request from nova site'
+
   let(:user) { create(:user) }
 
   describe 'GET #show' do

--- a/nova/spec/controllers/api/remit_requests_controller_spec.rb
+++ b/nova/spec/controllers/api/remit_requests_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Api::RemitRequestsController, type: :controller do
+  include_context 'request from nova site'
+
   let(:user) { create(:user) }
   let(:requested_user) { create(:user) }
   let(:remit_request) { create(:remit_request, user: user, requested_user: requested_user) }

--- a/nova/spec/controllers/api/users_controller_spec.rb
+++ b/nova/spec/controllers/api/users_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Api::UsersController, type: :controller do
+  include_context 'request from nova site'
+
   let(:user) { create(:user) }
 
   describe 'GET #show' do

--- a/nova/spec/support/shared_context/api_request_header.rb
+++ b/nova/spec/support/shared_context/api_request_header.rb
@@ -1,0 +1,8 @@
+# RSpecでのリクエスト時に、ヘッダーを設定するshared_context
+# api/application_controller.rb での、CSRF対策のチェックを満たす為に必要になる
+RSpec.shared_context 'request from nova site' do
+  before do
+    request.headers['Host'] = "example.com"
+    request.headers['Origin'] = "http://example.com"
+  end
+end


### PR DESCRIPTION
Issue : #15 

`/api` にCSRF脆弱性があったのでその対策。
OWASPの https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Verifying_Same_Origin_with_Standard_Headers に則って OriginとHostの一致を検証した。

CSRFを狙った、nova以外のサイトからのリクエストの場合は `headers['Host']` と `headers['Origin']` が一致しないことを利用したもの。

close #15 