### PR TITLE
RemitRequestからRemitRequestResultに移す際に、悲観的ロックを掛けるように

### DIFF
--- a/nova/app/models/remit_request.rb
+++ b/nova/app/models/remit_request.rb
@@ -38,7 +38,7 @@ class RemitRequest < ApplicationRecord
     finalize_with_lock!(RemitRequestResult::RESULT_REJECTED)
   end
 
-  def canceled!
+  def cancel!
     finalize_with_lock!(RemitRequestResult::RESULT_CANCELED)
   end
 
@@ -55,7 +55,6 @@ class RemitRequest < ApplicationRecord
     ActiveRecord::Base.transaction do
       lock!
       finalize!(result)
-      save!
     end
   end
 end

--- a/nova/app/models/remit_request.rb
+++ b/nova/app/models/remit_request.rb
@@ -35,14 +35,27 @@ class RemitRequest < ApplicationRecord
   end
 
   def reject!
-    ActiveRecord::Base.transaction do
-      RemitRequestResult.create_from_remit_request!(self, RemitRequestResult::RESULT_REJECTED)
-      destroy!
-    end
+    finalize_with_lock!(RemitRequestResult::RESULT_REJECTED)
   end
 
-  def cancel!
-    RemitRequestResult.create_from_remit_request!(self, RemitRequestResult::RESULT_CANCELED)
+  def canceled!
+    finalize_with_lock!(RemitRequestResult::RESULT_CANCELED)
+  end
+
+  # RemitRequestをRemitRequestResultに移す
+  # 既にremit_requetに対してロックを獲得している時に使うメソッド
+  # 獲得していなければ .finalize_with_lock! を用いる
+  def finalize!(result)
+    RemitRequestResult.create_from_remit_request!(self, result)
     destroy!
+  end
+
+  # lockを獲得しながらRemitRequestをRemitRequestResultに移す
+  def finalize_with_lock!(result)
+    ActiveRecord::Base.transaction do
+      lock!
+      finalize!(result)
+      save!
+    end
   end
 end

--- a/nova/app/models/remit_request.rb
+++ b/nova/app/models/remit_request.rb
@@ -44,7 +44,7 @@ class RemitRequest < ApplicationRecord
 
   # RemitRequestをRemitRequestResultに移す
   # 既にremit_requetに対してロックを獲得している時に使うメソッド
-  # 獲得していなければ .finalize_with_lock! を用いる
+  # ロック獲得が必要であれば .finalize_with_lock! を用いること
   def finalize!(result)
     RemitRequestResult.create_from_remit_request!(self, result)
     destroy!

--- a/nova/app/services/remit_service.rb
+++ b/nova/app/services/remit_service.rb
@@ -9,15 +9,22 @@ class RemitService
         user_balance = remit_request.user.balance
         requested_user_balance = remit_request.requested_user.balance
 
-        # balanceの整合性を担保するため、悲観的ロックをかける
-        aquire_lock!([user_balance, requested_user_balance])
+        # 整合性を担保するため、悲観的ロックをかける
+        # # 悲観的ロックの理由
+        # ## Balance
+        # 送金処理中に残高が減ってしまい、本来送金できるべきではないのに送金できてしまうことを防ぐため
+        #
+        # ## RemitRequest
+        # 送金処理中にRemitRequestが削除等され、RemitRequestが存在しない状態で送金処理が行われないようにするため
+        lock_targets = [remit_request, user_balance, requested_user_balance]
+        aquire_lock!(lock_targets)
 
         raise InsufficientBalanceError unless can_remit?(requested_user_balance, remit_request.amount)
 
         transfer_balance!(user_balance, requested_user_balance, remit_request.amount)
         finalize_remit_request!(remit_request)
 
-        release_lock!([user_balance, requested_user_balance])
+        release_lock!(lock_targets)
       end
     end
 
@@ -35,13 +42,13 @@ class RemitService
       remit_request.destroy!
     end
 
-    # balanceの整合性を担保するため悲観的行ロックを獲得する
+    # 整合性を担保するため悲観的行ロックを獲得する
     # デッドロックを防ぐため、id昇順にロックを獲得していく
     def aquire_lock!(balances)
       balances.sort_by(&:id).each(&:lock!)
     end
 
-    # balanceの整合性を担保するため悲観的行ロックを開放する
+    # 整合性を担保するため悲観的行ロックを開放する
     # デッドロックを防ぐため、aquire_lock!とは逆順で行ロックを開放する
     def release_lock!(balances)
       balances.sort_by(&:id).reverse.each(&:save!)

--- a/nova/app/services/remit_service.rb
+++ b/nova/app/services/remit_service.rb
@@ -22,7 +22,7 @@ class RemitService
         raise InsufficientBalanceError unless can_remit?(requested_user_balance, remit_request.amount)
 
         transfer_balance!(user_balance, requested_user_balance, remit_request.amount)
-        finalize_remit_request!(remit_request)
+        remit_request.finalize!(RemitRequestResult::RESULT_ACCEPTED)
 
         release_lock!(lock_targets)
       end
@@ -37,11 +37,6 @@ class RemitService
     def transfer_balance!(user_balance, requested_user_balance, amount)
       requested_user_balance.withdraw!(amount)
       user_balance.deposit!(amount)
-    end
-
-    def finalize_remit_request!(remit_request)
-      RemitRequestResult.create_from_remit_request!(remit_request, RemitRequestResult::RESULT_ACCEPTED)
-      remit_request.destroy!
     end
 
     # 整合性を担保するため悲観的行ロックを獲得する

--- a/nova/app/services/remit_service.rb
+++ b/nova/app/services/remit_service.rb
@@ -28,6 +28,8 @@ class RemitService
       end
     end
 
+    private
+
     def can_remit?(requested_user_balance, amount)
       requested_user_balance.can_withdraw?(amount)
     end

--- a/nova/app/services/remit_service.rb
+++ b/nova/app/services/remit_service.rb
@@ -23,8 +23,6 @@ class RemitService
 
         transfer_balance!(user_balance, requested_user_balance, remit_request.amount)
         remit_request.finalize!(RemitRequestResult::RESULT_ACCEPTED)
-
-        release_lock!(lock_targets)
       end
     end
 
@@ -43,12 +41,6 @@ class RemitService
     # デッドロックを防ぐため、id昇順にロックを獲得していく
     def aquire_lock!(balances)
       balances.sort_by(&:id).each(&:lock!)
-    end
-
-    # 整合性を担保するため悲観的行ロックを開放する
-    # デッドロックを防ぐため、aquire_lock!とは逆順で行ロックを開放する
-    def release_lock!(balances)
-      balances.sort_by(&:id).reverse.each(&:save!)
     end
   end
 end


### PR DESCRIPTION
`RemitService` でのトランザクション中に処理対象の`RemitRequest` が削除された場合に、送金するべきでないにも関わらず送金が行われてしまう問題があった。

なので、 `RemitRquest` に対して悲観的ロックをかけて、 `RemitService.execute!` 中はRemitRequestが必ず存在することを担保することとした。