### PR TITLE
トップページの残高表示にbalanceの内容を用いるように

### DIFF
--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -79,8 +79,11 @@ document.addEventListener('DOMContentLoaded', function() {
         self.user = json;
       });
 
+      api.get('/api/balance').then(function(json) {
+        self.amount = json.amount
+      })
+
       api.get('/api/charges').then(function(json) {
-        self.amount = json.amount;
         self.charges = json.charges;
       });
 

--- a/nova/app/controllers/api/balances_controller.rb
+++ b/nova/app/controllers/api/balances_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Api::BalancesController < Api::ApplicationController
+  def show
+    render json: current_user.balance.as_json(only: %i[user_id amount])
+  end
+end

--- a/nova/app/controllers/api/charges_controller.rb
+++ b/nova/app/controllers/api/charges_controller.rb
@@ -2,22 +2,9 @@
 
 class Api::ChargesController < Api::ApplicationController
   def index
-    charge_total = 0
-    current_user.charges.each do |charge|
-      charge_total += charge.amount
-    end
-    remit_total = 0
-    current_user.received_remit_requests.where.not(accepted_at: nil).each do |remit|
-      remit_total += remit.amount
-    end
-    current_user.sent_remit_requests.where.not(accepted_at: nil).each do |remit|
-      remit_total -= remit.amount
-    end
-    balance_total = charge_total - remit_total
-
     @charges = current_user.charges.order(id: :desc).limit(50)
 
-    render json: { amount: balance_total, charges: @charges }
+    render json: { charges: @charges }
   end
 
   def create

--- a/nova/config/routes.rb
+++ b/nova/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
       end
     end
     resources :remit_request_results, only: %i[index]
+    resource :balance, only: %i[show]
   end
   get '/dashboard', to: 'dashboard#show'
 


### PR DESCRIPTION
トップページの残高表示で、 毎回計算するのではなくbalanceの内容を使うようにした

それに伴い、 `ChargesController#index` の計算が不要になったので削除

close #41 