### PR TITLE
本番デプロイ時にSidekiqが死ななかったので、ちゃんと殺すように

### DIFF
--- a/nova/appspec.yml
+++ b/nova/appspec.yml
@@ -13,7 +13,7 @@ hooks:
   ApplicationStop:
     - location: scripts/stop.sh
       timeout: 300
-      runas: root
+      runas: ubuntu
   BeforeInstall:
     - location: scripts/clean.sh
       timeout: 300

--- a/nova/scripts/stop.sh
+++ b/nova/scripts/stop.sh
@@ -2,8 +2,13 @@
 
 set -e
 
+eval "$(rbenv init -)"
+
+cd /var/nova/current
+export RAILS_ENV=production
+
 if [ -f /var/nova/current/tmp/pids/puma.pid ]; then
-  su -l ubuntu -c 'kill -s TERM `cat /var/nova/current/tmp/pids/puma.pid`'
+  kill -s TERM $(cat /var/nova/current/tmp/pids/puma.pid)
 fi
 
 if [ -f /var/nova/current/tmp/pids/sidekiq.pid ]; then


### PR DESCRIPTION
`bundler` が見つからなく、 `sidekiqctl` が叩けずにSidekiqを殺せていなかった...

ubuntuユーザにして、 `rbenv init - `を叩いてrbenvでインストールされたrubyを使うようにした 👍 

そしてちゃんと殺せるようになった 😇 