### PR TITLE
RailsのタイムゾーンをAsia/Tokyoにし、ARのタイムゾーンをutcに固定した

### DIFF
--- a/nova/config/application.rb
+++ b/nova/config/application.rb
@@ -29,5 +29,8 @@ module Nova
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.time_zone = 'Asia/Tokyo'
+    config.active_record.default_timezone = :utc
   end
 end


### PR DESCRIPTION
☝️ タイトルの通り

DBに保存する時刻情報は必ずutcになるようにし、それをRails側でAsia/Tokyoにコンバートして表示するようにした。

close #64 

