### PR TITLE
Show devise errors

### DIFF
--- a/nova/app/views/users/_devise_errors.html.erb
+++ b/nova/app/views/users/_devise_errors.html.erb
@@ -1,0 +1,14 @@
+<% if @user.errors.present? || flash.present? %>
+  <article class="message is-danger">
+    <div class="message-body">
+      <ul>
+        <% flash.each do |key, value| %>
+          <%= content_tag(:li, value, class: "#{key}") %>
+        <% end %>
+        <% @user.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  </article>
+<% end %>

--- a/nova/app/views/users/registrations/edit.html.erb
+++ b/nova/app/views/users/registrations/edit.html.erb
@@ -1,7 +1,8 @@
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+
+  <%= render 'users/devise_errors' %>
 
   <div class="field">
     <%= f.label :email %><br />

--- a/nova/app/views/users/registrations/new.html.erb
+++ b/nova/app/views/users/registrations/new.html.erb
@@ -1,6 +1,9 @@
 <h2>Sign up</h2>
 
 <%= form_for(@user, url: registration_path(@user)) do |f| %>
+
+  <%= render 'users/devise_errors' %>
+
   <div class="field">
     <%= f.label :nickname %>
     <div class="control">

--- a/nova/app/views/users/sessions/new.html.erb
+++ b/nova/app/views/users/sessions/new.html.erb
@@ -2,6 +2,8 @@
 
 <%= form_for(@user, url: user_session_path(@user)) do |f| %>
 
+  <%= render 'users/devise_errors' %>
+
   <div class="field control">
     <%= f.label :email %><br />
     <div class="control">

--- a/nova/config/locales/devise.ja.yml
+++ b/nova/config/locales/devise.ja.yml
@@ -1,0 +1,64 @@
+ja:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"
+
+


### PR DESCRIPTION
* ユーザログイン
* ユーザー登録

にてdeviseのエラーメッセージを表示するようにした

![image](https://user-images.githubusercontent.com/7167152/40050162-9ef9aefa-5871-11e8-91ed-156fff75c518.png)

![image](https://user-images.githubusercontent.com/7167152/40050187-af7b199e-5871-11e8-9625-66f6fbf25acf.png)


エラーメッセージのlocaleは雑にenのものをコピーしてしまった　