### PR TITLE
本番でES6文法が使えずにデプロイがコケるので使えるように

### DIFF
--- a/nova/config/environments/production.rb
+++ b/nova/config/environments/production.rb
@@ -26,7 +26,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # ES6 の文法を許可するために harmony option を true としている
+  config.assets.js_compressor = Uglifier.new(harmony: :true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
thanks to : https://github.com/tnandate/2018-newbies/pull/99

asset precompile 時のminify時にES6文法を使えるようにした