### PR TITLE
Increase puma worker

### DIFF
--- a/nova/config/puma.rb
+++ b/nova/config/puma.rb
@@ -31,7 +31,7 @@ environment ENV.fetch('RAILS_ENV') { 'development' }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
pumaのworker数を1 -> 2に変更

productionサーバのCPUが余っている &   これからcapacityを増やすために